### PR TITLE
Fix YouTube link formatting and capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A Experimental, C++20 & DX12 renderer made for learning and trying out various g
 ![](Assets/Screenshots/Deferred1.png)
 
 # Showcase Video
-[Youtube link] (https://youtu.be/hKeVVCpzVhQ)
+[YouTube link](https://youtu.be/hKeVVCpzVhQ)
 
 # Third Party Libraries
 * [Dear ImGUI](https://github.com/ocornut/imgui)


### PR DESCRIPTION
Remove missing space between `[...]` and `(...)` to make the Markdown render the link properly.